### PR TITLE
URL Cleanup

### DIFF
--- a/java/stocks/pom.xml
+++ b/java/stocks/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>Spring Rabbit Stocks</name>
-	<url>http://www.springframework.org</url>
+	<url>https://www.springframework.org</url>
 	<description>
 		<![CDATA[
       This project shows the usage of Spring Rabbit integration classes.
@@ -194,7 +194,7 @@
 		<repository>
 			<id>org.springsource.maven.snapshot</id>
 			<name>SpringSource Maven Central-compatible Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<updatePolicy>daily</updatePolicy>
 			</snapshots>
@@ -202,25 +202,25 @@
 		<repository>
 			<id>spring-milestone</id>
 			<name>Spring Maven MILESTONE Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 		<repository>
 			<id>standard repo</id>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 		</repository>
 		<repository>
 			<id>mirror repo</id>
-			<url>http://mirrors.ibiblio.org/pub/mirrors/maven2</url>
+			<url>/maven2</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.release</id>
 			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.external</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/external</url>
+			<url>https://repository.springsource.com/maven/bundles/external</url>
 		</repository>
 		<repository>
 			<id>dist.gemstone.com</id>
@@ -312,14 +312,14 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>Codehaus</id>
-			<url>http://repository.codehaus.org/</url>
+			<url>https://repository.codehaus.org/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
 	<distributionManagement>
-		<downloadUrl>http://www.springframework.org/download</downloadUrl>
+		<downloadUrl>https://www.springframework.org/download</downloadUrl>
 		<site>
 			<id>staging</id>
 			<url>file:///${user.dir}/target/staging/org.springframework.batch.archetype/${project.artifactId}</url>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://dist.gemstone.com/maven/release (404) migrated to:  
  http://dist.gemstone.com/maven/release ([https](https://dist.gemstone.com/maven/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://mirrors.ibiblio.org/pub/mirrors/maven2 (301) migrated to:  
  /maven2 ([https](https://mirrors.ibiblio.org/pub/mirrors/maven2) result IllegalArgumentException).
* http://repository.codehaus.org/ (UnknownHostException) migrated to:  
  https://repository.codehaus.org/ ([https](https://repository.codehaus.org/) result UnknownHostException).
* http://repository.springsource.com/maven/bundles/external (404) migrated to:  
  https://repository.springsource.com/maven/bundles/external ([https](https://repository.springsource.com/maven/bundles/external) result 404).
* http://repository.springsource.com/maven/bundles/release (404) migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).
* http://www.springframework.org/download (404) migrated to:  
  https://www.springframework.org/download ([https](https://www.springframework.org/download) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://www.springframework.org migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo1.maven.org/maven2 migrated to:  
  https://repo1.maven.org/maven2 ([https](https://repo1.maven.org/maven2) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance